### PR TITLE
Fixed implmentation for assigning lambdas as a cognito trigger

### DIFF
--- a/makegqlserverless.js
+++ b/makegqlserverless.js
@@ -213,7 +213,6 @@ const {
     if (runtime) o.runtime = runtime;
     if (name) o.name = name;
     if (description) o.description = description;
-    if (cognitoUserPool) o.cognitoUserPool = { pool: cognitoUserPool, trigger };
     const tags = Object.entries(rest)
       .filter(([k, v]) => k.indexOf("tag-") === 0)
       .map(([k, v]) => [k.substring(4), v]);
@@ -225,7 +224,16 @@ const {
     if (envs.length)
       o.environment = envsa.reduce((o, [k, v]) => ({ ...o, [k]: v }), {});
     if (
-      [s3, sqs, dynamodb, http, schedule, rate, cloudwatchLog].find(Boolean)
+      [
+        s3,
+        sqs,
+        dynamodb,
+        http,
+        schedule,
+        rate,
+        cloudwatchLog,
+        cognitoUserPool
+      ].find(Boolean)
     ) {
       o.events = [];
       if (s3) s3.split(",").forEach(s3 => o.events.push({ s3 }));
@@ -247,6 +255,17 @@ const {
         });
       if (rate) o.events["rate"] = `rate(${rate} minute)`;
       if (cloudwatchLog) o.events["cloudwatchLog"] = cloudwatchLog.split(",");
+      if (cognitoUserPool) {
+        if (!o.events["cognitoUserPool"]) {
+          o.events["cognitoUserPool"] = [];
+        }
+        o.events.push({
+          cognitoUserPool: {
+            pool: cognitoUserPool,
+            trigger
+          }
+        });
+      }
     }
     if (o) functions[prependedName] = o;
     //Make resolver text

--- a/makegqlserverless.js
+++ b/makegqlserverless.js
@@ -256,9 +256,6 @@ const {
       if (rate) o.events["rate"] = `rate(${rate} minute)`;
       if (cloudwatchLog) o.events["cloudwatchLog"] = cloudwatchLog.split(",");
       if (cognitoUserPool) {
-        if (!o.events["cognitoUserPool"]) {
-          o.events["cognitoUserPool"] = [];
-        }
         o.events.push({
           cognitoUserPool: {
             pool: cognitoUserPool,


### PR DESCRIPTION
### Change
Serverless requires `cognitoUserPool` field to be defined in a functions `events` array. 

Current implementation sets `cognitoUserPool`as a sibling field to `events`

[See example of configuring user pool with serverless](https://serverless.com/framework/docs/providers/aws/events/cognito-user-pool/)